### PR TITLE
Minors fix

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,35 +1,35 @@
 jmose_command_scheduler_list:
-    pattern:  /command-scheduler/list
+    path:  /command-scheduler/list
     defaults: { _controller: JMoseCommandSchedulerBundle:List:index }
 
 jmose_command_scheduler_action_toggle:
-    pattern:  /command-scheduler/action/toggle/{id}
+    path:  /command-scheduler/action/toggle/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:toggle }
 
 jmose_command_scheduler_action_remove:
-    pattern:  /command-scheduler/action/remove/{id}
+    path:  /command-scheduler/action/remove/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:remove }
 
 jmose_command_scheduler_action_execute:
-    pattern:  /command-scheduler/action/execute/{id}
+    path:  /command-scheduler/action/execute/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:execute }
 
 jmose_command_scheduler_action_unlock:
-    pattern:  /command-scheduler/action/unlock/{id}
+    path:  /command-scheduler/action/unlock/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:unlock }
 
 jmose_command_scheduler_detail_index:
-    pattern:  /command-scheduler/detail/view/
+    path:  /command-scheduler/detail/view/
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:index }
 
 jmose_command_scheduler_detail_edit:
-    pattern:  /command-scheduler/detail/edit/{scheduledCommandId}
+    path:  /command-scheduler/detail/edit/{scheduledCommandId}
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:initEditScheduledCommand }
 
 jmose_command_scheduler_detail_new:
-    pattern:  /command-scheduler/detail/new
+    path:  /command-scheduler/detail/new
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:initNewScheduledCommand }
 
 jmose_command_scheduler_detail_save:
-    pattern:  /command-scheduler/detail/save
+    path:  /command-scheduler/detail/save
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:save }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/symfony": "~2.3",
         "sensio/framework-extra-bundle": "~2.3|~3.0",
         "twig/twig": "~1.15",
-        "doctrine/orm": "~2.2,>=2.2.3,<2.5",
+        "doctrine/orm": "~2.2,>=2.2.3,<2.6",
         "doctrine/doctrine-bundle": "~1.0",
         "mtdowling/cron-expression": "~1.0"
     },


### PR DESCRIPTION
Remove pattern (deprecated) property from route.yml - #19 
Allow Doctrine 2.6 in composer.json