### PR TITLE
added external monitoring capability

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -171,13 +171,14 @@ class ExecuteCommand extends ContainerAwareCommand
 
         // Use a StreamOutput to redirect write() and writeln() in a log file
         $path = $this->logPath;
-        if($path !== false) {
+        $file =  $scheduledCommand->getLogFile();
+        if(($path !== false) && ("null" != strtolower($file))) {
             // append directory separator if there is none
             if(substr($path, -1) !== DIRECTORY_SEPARATOR) {
                 $path = $path . DIRECTORY_SEPARATOR;
             }
             //
-            $path = $path . $scheduledCommand->getLogFile();
+            $path = $path . $file;
 
 	        // initialize streamoutput with specified target and verbosity
 	        $logOutput = new StreamOutput(fopen(

--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -7,9 +7,11 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
+use Symfony\Component\Validator\Constraints\Null;
 
 /**
  * Class ExecuteCommand : This class is the entry point to execute all scheduled command
@@ -63,7 +65,13 @@ class ExecuteCommand extends ContainerAwareCommand
     {
         $this->dumpMode = $input->getOption('dump');
         $this->logPath = rtrim($this->getContainer()->getParameter('jmose_command_scheduler.log_path'), '/\\');
-        $this->logPath .= DIRECTORY_SEPARATOR;
+
+	    // set logpath to false if specified in parameters to suppress logging
+	    if("false" == $this->logPath) {
+		    $this->logPath = false;
+	    } else {
+		    $this->logPath .= DIRECTORY_SEPARATOR;
+	    }
 
         // store the original verbosity before apply the quiet parameter
         $this->commandsVerbosity = $output->getVerbosity();
@@ -87,7 +95,7 @@ class ExecuteCommand extends ContainerAwareCommand
         $output->writeln('<info>Start : ' . ($this->dumpMode ? 'Dump' : 'Execute') . ' all scheduled command</info>');
 
         // Before continue, we check that the output file is valid and writable (except for gaufrette)
-        if (strpos($this->logPath, 'gaufrette:') !== 0 && false === is_writable($this->logPath)) {
+        if (false !== $this->logPath && strpos($this->logPath, 'gaufrette:') !== 0 && false === is_writable($this->logPath)) {
             $output->writeln(
                 '<error>'.$this->logPath.
                 ' not found or not writable. You should override `log_path` in your config.yml'.'</error>'
@@ -162,11 +170,22 @@ class ExecuteCommand extends ContainerAwareCommand
         ));
 
         // Use a StreamOutput to redirect write() and writeln() in a log file
-        $logOutput = new StreamOutput(fopen(
-            $this->getContainer()->getParameter('jmose_command_scheduler.log_path') .
-            $scheduledCommand->getLogFile(), 'a', false
-        ));
-        $logOutput->setVerbosity($this->commandsVerbosity);
+        $path = $this->logPath;
+        if($path !== false) {
+            // append directory separator if there is none
+            if(substr($path, -1) !== DIRECTORY_SEPARATOR) {
+                $path = $path . DIRECTORY_SEPARATOR;
+            }
+            //
+            $path = $path . $scheduledCommand->getLogFile();
+
+	        // initialize streamoutput with specified target and verbosity
+	        $logOutput = new StreamOutput(fopen(
+	            $path, 'a', false
+	        ), $this->commandsVerbosity);
+        } else { // initialize nulloutput to disable output
+            $logOutput = new NullOutput();
+        }
 
         // Execute command and get return code
         try {

--- a/Command/MonitorCommand.php
+++ b/Command/MonitorCommand.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace JMose\CommandSchedulerBundle\Command;
+
+use Cron\CronExpression;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
+use Symfony\Component\Validator\Constraints\Null;
+
+/**
+ * Class ExecuteCommand : This class is the entry point to execute all scheduled command
+ *
+ * @author  Julien Guyon <julienguyon@hotmail.com>
+ * @package JMose\CommandSchedulerBundle\Command
+ */
+class MonitorCommand extends ContainerAwareCommand
+{
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    /**
+     * @var string
+     */
+    private $logPath;
+
+    /**
+     * @var boolean
+     */
+    private $dumpMode;
+
+    /**
+     * @var integer
+     */
+    private $commandsVerbosity;
+
+    /** @var string|array receiver for statusmail if an error occured */
+    private $receiver;
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('scheduler:monitor')
+            ->setDescription('Monitor scheduled commands')
+            ->addOption('dump', null, InputOption::VALUE_NONE, 'Display result before mailing (even if no receiver is set)')
+            ->addOption('no-output', null, InputOption::VALUE_NONE, 'Disable output message from scheduler')
+            ->setHelp('This class is for monitoring all active commands.');
+    }
+
+    /**
+     * Initialize parameters and services used in execute function
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->dumpMode = $input->getOption('dump');
+        $this->logPath = rtrim($this->getContainer()->getParameter('jmose_command_scheduler.log_path'), '/\\');
+
+        $this->receiver = $this->getContainer()->getParameter('jmose_command_scheduler.monitor_mail');
+
+	    // set logpath to false if specified in parameters to suppress logging
+	    if("false" == $this->logPath) {
+		    $this->logPath = false;
+	    } else {
+		    $this->logPath .= DIRECTORY_SEPARATOR;
+	    }
+
+        // store the original verbosity before apply the quiet parameter
+        $this->commandsVerbosity = $output->getVerbosity();
+
+        if( true === $input->getOption('no-output')){
+            $output->setVerbosity( OutputInterface::VERBOSITY_QUIET );
+        }
+
+        $this->em = $this->getContainer()->get('doctrine')->getManager(
+            $this->getContainer()->getParameter('jmose_command_scheduler.doctrine_manager')
+        );
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Start : ' . ($this->dumpMode ? 'Dump' : 'Execute') . ' all scheduled command</info>');
+
+        // Before continue, we check that the output file is valid and writable (except for gaufrette)
+        if (false !== $this->logPath && strpos($this->logPath, 'gaufrette:') !== 0 && false === is_writable($this->logPath)) {
+            $output->writeln(
+                '<error>'.$this->logPath.
+                ' not found or not writable. You should override `log_path` in your config.yml'.'</error>'
+            );
+
+            return;
+        }
+
+        $commands = $this->em->getRepository('JMoseCommandSchedulerBundle:ScheduledCommand')->findAll();
+
+        $timeoutValue = $this->getContainer()->getParameter('jmose_command_scheduler.lock_timeout');
+
+        $failed = array();
+        $now = time();
+
+        foreach ($commands as $command) {
+                // don't care about disabled commands
+                if($command->isDisabled()) {
+                    continue;
+                }
+
+                $executionTime = $command->getLastExecution();
+                $executionTimestamp = $executionTime->getTimestamp();
+
+                $timedOut = (($executionTimestamp + $timeoutValue) < $now);
+
+                if(
+                    ($command->getLastReturnCode() != 0) || // last return code not OK
+                    (
+                        $command->getLocked() &&
+                        (
+                            ($timeoutValue === false) || // don't check for timeouts -> locked is bad
+                            $timedOut // check for timeouts, but (starttime + timeout) is in the past
+                        )
+                    )
+                ) {
+                    $failed[$command->getName()] = array(
+                        'LAST_RETURN_CODE' => $command->getLastReturnCode(),
+                        'B_LOCKED' => $command->getLocked() ? 'true' : 'false',
+                        'DH_LAST_EXECUTION' => $executionTime
+                    );
+                }
+        }
+
+        if (count($failed)) { // errors occured
+            $message = "";
+
+            foreach($failed as $commandName => $fail) {
+                $message .= sprintf("%s: returncode %s, locked: %s, last execution: %s\n",
+                    $commandName,
+                    $fail['LAST_RETURN_CODE'],
+                    $fail['B_LOCKED'],
+                    $fail['DH_LAST_EXECUTION']->format('Y-m-d H:i')
+                );
+            }
+
+            if($this->dumpMode) {
+                $output->writeln($this->dumpMode);
+            }
+
+            // prepare email constants
+            $hostname = gethostname();
+            $subject = "cronjob monitoring " . $hostname;
+            $headers = 'From: webmaster@' . $hostname . "\r\n" .
+                'X-Mailer: PHP/' . phpversion();
+
+            // send mail to every receiver
+            if(count($this->receiver)) {
+                foreach($this->receiver as $rcv) {
+                    mail(trim($rcv), $subject, $message, $headers);
+                }
+            }
+        } else if($this->dumpMode) { // no errors + dumpmode
+            $output->writeln('Nothing to do.');
+        }
+    }
+}

--- a/Controller/ListController.php
+++ b/Controller/ListController.php
@@ -124,7 +124,7 @@ class ListController extends Controller
             }
 
             $executionTime = $command->getLastExecution();
-            $executionTimestamp = strtotime($executionTime->date);
+            $executionTimestamp = $executionTime->getTimestamp();
 
             $timedOut = (($executionTimestamp + $timeoutValue) < $now);
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('doctrine_manager')->defaultValue('default')->end()
                 ->scalarNode('log_path')->defaultValue('app\logs')->end()
-                ->scalarNode('lock_timeout')->defaultValue('0')->end()
+                ->scalarNode('lock_timeout')->defaultValue(false)->end()
                 ->variableNode('excluded_command_namespaces')
                     ->defaultValue(array(
                         '_global',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(array())
                     ->prototype('scalar')->end()
                 ->end()
+                ->scalarNode('send_ok')->defaultValue(false)->end()
                 ->variableNode('excluded_command_namespaces')
                     ->defaultValue(array(
                         '_global',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('doctrine_manager')->defaultValue('default')->end()
                 ->scalarNode('log_path')->defaultValue('app\logs')->end()
+                ->scalarNode('lock_timeout')->defaultValue('0')->end()
                 ->variableNode('excluded_command_namespaces')
                     ->defaultValue(array(
                         '_global',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,10 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('doctrine_manager')->defaultValue('default')->end()
                 ->scalarNode('log_path')->defaultValue('app\logs')->end()
                 ->scalarNode('lock_timeout')->defaultValue(false)->end()
+                ->arrayNode('monitor_mail')
+                    ->defaultValue(array())
+                    ->prototype('scalar')->end()
+                ->end()
                 ->variableNode('excluded_command_namespaces')
                     ->defaultValue(array(
                         '_global',

--- a/DependencyInjection/JMoseCommandSchedulerExtension.php
+++ b/DependencyInjection/JMoseCommandSchedulerExtension.php
@@ -20,6 +20,7 @@ class JMoseCommandSchedulerExtension extends Extension
     {
         $BCBreakParams = array(
             'jmose_command_scheduler.log_path' => 'log_path',
+            'jmose_command_scheduler.log_timeout' => false,
             'jmose_command_scheduler.command_choice_list.excluded_namespaces' => 'excluded_command_namespaces',
             'jmose_command_scheduler.doctrine_manager' => 'doctrine_manager',
         );

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,35 +1,39 @@
 jmose_command_scheduler_list:
-    path:  /command-scheduler/list
+    pattern:  /command-scheduler/list
     defaults: { _controller: JMoseCommandSchedulerBundle:List:index }
 
+jmose_command_scheduler_monitor:
+    pattern:  /command-scheduler/monitor
+    defaults: { _controller: JMoseCommandSchedulerBundle:List:monitor }
+
 jmose_command_scheduler_action_toggle:
-    path:  /command-scheduler/action/toggle/{id}
+    pattern:  /command-scheduler/action/toggle/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:toggle }
 
 jmose_command_scheduler_action_remove:
-    path:  /command-scheduler/action/remove/{id}
+    pattern:  /command-scheduler/action/remove/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:remove }
 
 jmose_command_scheduler_action_execute:
-    path:  /command-scheduler/action/execute/{id}
+    pattern:  /command-scheduler/action/execute/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:execute }
 
 jmose_command_scheduler_action_unlock:
-    path:  /command-scheduler/action/unlock/{id}
+    pattern:  /command-scheduler/action/unlock/{id}
     defaults: { _controller: JMoseCommandSchedulerBundle:List:unlock }
 
 jmose_command_scheduler_detail_index:
-    path:  /command-scheduler/detail/view/
+    pattern:  /command-scheduler/detail/view/
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:index }
 
 jmose_command_scheduler_detail_edit:
-    path:  /command-scheduler/detail/edit/{scheduledCommandId}
+    pattern:  /command-scheduler/detail/edit/{scheduledCommandId}
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:initEditScheduledCommand }
 
 jmose_command_scheduler_detail_new:
-    path:  /command-scheduler/detail/new
+    pattern:  /command-scheduler/detail/new
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:initNewScheduledCommand }
 
 jmose_command_scheduler_detail_save:
-    path:  /command-scheduler/detail/save
+    pattern:  /command-scheduler/detail/save
     defaults: { _controller: JMoseCommandSchedulerBundle:Detail:save }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -98,9 +98,12 @@ jmose_command_scheduler:
 
     # Default directory where scheduler will write output files
     #  This default value assume that php app/console is launched from project's root and that the directory is writable
+    # if log_path is set to false, logging to files is disabled at all 
     log_path: app\logs\
     # This default value disables timeout checking (see monitoring), set to a numeric value (seconds) to enable it
     log_timeout: false
+    # receivers for reporting mails
+    monitor_mail: [ "nobody@example.com" ]
 
     # Namespaces listed here won't be listed in the list
     excluded_command_namespaces:
@@ -173,3 +176,5 @@ To run the check simply call
 `http://{you-app-root}/command-scheduler/monitor`
 
 The call returns a JSON object with either HTTP 200 and an empty array (everything ok) or HTTP 417 (Expectation failed) and an object containing all the (failed) jobs with name, last execution time, locked state and return code.
+
+For "internal" monitoring of jobs there is also a command "scheduler:monitor" which does the same check as the monitor call before except it sends emails to an arbitrary number of receivers (if the server allows sending mails with the "mail" command).

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -99,6 +99,8 @@ jmose_command_scheduler:
     # Default directory where scheduler will write output files
     #  This default value assume that php app/console is launched from project's root and that the directory is writable
     log_path: app\logs\
+    # This default value disables timeout checking (see monitoring), set to a numeric value (seconds) to enable it
+    log_timeout: false
 
     # Namespaces listed here won't be listed in the list
     excluded_command_namespaces:
@@ -156,3 +158,18 @@ This system avoid to have simultaneous process for the same command.
 Thus, if an non-catchable error occurs, the command won't be executed again unless the problem is solved and the task is unlocked manually.
 
 For any comments, questions, or bug report, use the  [Github issue tracker](https://github.com/J-Mose/CommandSchedulerBundle/issues).
+
+Monitor Jobs
+=============
+
+To enable (external) checks if the jobs are running correctly there is a URL which runs a check with the following requirements/limits:
+ 
+ - only check enabled commands
+ - return value not equal 0 means there is something wrong
+ - running jobs can be checked for a maximum runtime
+ 
+To run the check simply call
+
+`http://{you-app-root}/command-scheduler/monitor`
+
+The call returns a JSON object with either HTTP 200 and an empty array (everything ok) or HTTP 417 (Expectation failed) and an object containing all the (failed) jobs with name, last execution time, locked state and return code.

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -104,6 +104,8 @@ jmose_command_scheduler:
     log_timeout: false
     # receivers for reporting mails
     monitor_mail: [ "nobody@example.com" ]
+    # to send "everything's all right" emails to receivers for reporting mails set this value to "true"
+    send_ok: false
 
     # Namespaces listed here won't be listed in the list
     excluded_command_namespaces:
@@ -122,22 +124,22 @@ jmose_command_scheduler:
 
 Feel free to override it (especially `log_path`) in your `config.yml` file.
 
- 
+
 Usage
 ============
 
 After a successful installation, you can access to this URL:
 
-`http://{you-app-root}/command-scheduler/list`. 
+`http://{you-app-root}/command-scheduler/list`.
 
-From this screen, you can do following actions : 
+From this screen, you can do following actions :
   - Create a new scheduling
   - Edit an existing scheduling
   - Enable or disable scheduling (by clicking the "Power Off/On" switch)
   - Manually execute a command (It will be launched during the next `scheduler:execute`, regardless of the cron expression)
   - Unlock a task (if the lock is due to an unrecoverable error for example)
 
-After that, you have to set (every few minutes, it depends of your needs) the following command in your system : 
+After that, you have to set (every few minutes, it depends of your needs) the following command in your system :
 ``` bash
 $ php app/console scheduler:execute --env=env -vvv [--dump] [--no-output]
 ```
@@ -149,15 +151,15 @@ The `--env=` and `-v` (or `--verbosity`) arguments are passed to all scheduled c
 
 If you don't want to have any message (except error) from scheduler itself you can use the `--no-output` option.
 
-The `scheduler:execute` command will do following actions : 
+The `scheduler:execute` command will do following actions :
   - Get all scheduled commands in database (unlocked and enabled only)
   - Sort them by priority (desc)
   - Check if the command has to be executed at current time, based on its cron expression and on its last execution time
   - Execute eligible commands (without `exec` php function)
- 
-  
-**Note** : Each command is locked just before his execution (and unlocked after). 
-This system avoid to have simultaneous process for the same command. 
+
+
+**Note** : Each command is locked just before his execution (and unlocked after).
+This system avoid to have simultaneous process for the same command.
 Thus, if an non-catchable error occurs, the command won't be executed again unless the problem is solved and the task is unlocked manually.
 
 For any comments, questions, or bug report, use the  [Github issue tracker](https://github.com/J-Mose/CommandSchedulerBundle/issues).
@@ -166,11 +168,11 @@ Monitor Jobs
 =============
 
 To enable (external) checks if the jobs are running correctly there is a URL which runs a check with the following requirements/limits:
- 
+
  - only check enabled commands
  - return value not equal 0 means there is something wrong
  - running jobs can be checked for a maximum runtime
- 
+
 To run the check simply call
 
 `http://{you-app-root}/command-scheduler/monitor`
@@ -178,3 +180,4 @@ To run the check simply call
 The call returns a JSON object with either HTTP 200 and an empty array (everything ok) or HTTP 417 (Expectation failed) and an object containing all the (failed) jobs with name, last execution time, locked state and return code.
 
 For "internal" monitoring of jobs there is also a command "scheduler:monitor" which does the same check as the monitor call before except it sends emails to an arbitrary number of receivers (if the server allows sending mails with the "mail" command).
+As some kind of "self-monitoring" job the monitor command can be configured to send emails to all receivers if everything's ok - if there is no mail at all a problem occured.


### PR DESCRIPTION
we use external monitoring tools to monitor our servers. To check the state of our scheduled commands we added tracking capabilities which can be accessed by calling

`http://{you-app-root}/command-scheduler/monitor`

The URL returns a JSON object with detailed information and different HTTP status codes depending on the result.