### PR TITLE
Patch 1

### DIFF
--- a/Entity/ScheduledCommand.php
+++ b/Entity/ScheduledCommand.php
@@ -171,7 +171,7 @@ class ScheduledCommand
         if (null !== $this->arguments || '' != $this->arguments) {
             $flatArgsArray = explode(' ', preg_replace('/\s+/', ' ', $this->arguments));
             foreach ($flatArgsArray as $argument) {
-                $tmpArray = explode('=', $argument, 1);
+                $tmpArray = explode('=', $argument, 2);
                 if (count($tmpArray) == 1) {
                     $argsArray[$tmpArray[0]] = true;
                 } else {

--- a/Entity/ScheduledCommand.php
+++ b/Entity/ScheduledCommand.php
@@ -171,7 +171,7 @@ class ScheduledCommand
         if (null !== $this->arguments || '' != $this->arguments) {
             $flatArgsArray = explode(' ', preg_replace('/\s+/', ' ', $this->arguments));
             foreach ($flatArgsArray as $argument) {
-                $tmpArray = explode('=', $argument);
+                $tmpArray = explode('=', $argument, 1);
                 if (count($tmpArray) == 1) {
                     $argsArray[$tmpArray[0]] = true;
                 } else {


### PR DESCRIPTION
Hi, with a little chenage we can allow the user to write params like this:
--params=fileblock=1024&dir=/home

Using the third parameters in explode, this will correctly exploded in:
"--params" => "fileblock=1024&dir=/home"

Hope this help.

Regards, 
Fabio.
