### PR TITLE
fix(ExecuteCommand.php): disable interactive mode

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -166,6 +166,11 @@ class ExecuteCommand extends ContainerAwareCommand
             $scheduledCommand->getArguments(true)
         ));
 
+        // Disable interactive mode if the current command has no-interaction flag
+        if (true === $input->hasParameterOption(array('--no-interaction', '-n'))) {
+            $input->setInteractive(false);
+        }
+
         // Use a StreamOutput or NullOutput to redirect write() and writeln() in a log file
         if (false === $this->logPath || empty($scheduledCommand->getLogFile())) {
             $logOutput = new NullOutput();


### PR DESCRIPTION
This commit will take in account interactive mode for each scheduled command.
Currently each command build a new instance of inputArray and interactive mode is true by default.

Thank you for fixing it.