### PR TITLE
avoid running commands in parallel

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -144,11 +144,37 @@ class ExecuteCommand extends ContainerAwareCommand
      */
     private function executeCommand(ScheduledCommand $scheduledCommand, OutputInterface $output, InputInterface $input)
     {
-        $scheduledCommand = $this->em->merge($scheduledCommand);
-        $scheduledCommand->setLastExecution(new \DateTime());
-        $scheduledCommand->setLocked(true);
-        $this->em->flush();
 
+        //reload command from database before every execution to avoid parallel execution
+        $this->em->getConnection()->beginTransaction();
+        try {
+            $notLockedCommand = $this
+                ->em
+                ->getRepository('JMoseCommandSchedulerBundle:ScheduledCommand')
+                ->getNotLockedCommand($scheduledCommand);
+            //$notLockedCommand will be locked for avoiding parallel calls: http://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
+            if ($notLockedCommand === null) {
+                throw new \Exception();
+            }
+
+            $scheduledCommand = $notLockedCommand;
+            sleep(20);
+            $scheduledCommand->setLastExecution(new \DateTime());
+            $scheduledCommand->setLocked(true);
+            $scheduledCommand = $this->em->merge($scheduledCommand);
+            $this->em->flush();
+            $this->em->getConnection()->commit();
+        } catch (\Exception $e) {
+            $this->em->getConnection()->rollBack();
+            $output->writeln(
+                sprintf(
+                    '<error>Command %s is locked %s</error>',
+                    $scheduledCommand->getCommand(),
+                    (!empty($e->getMessage()) ? sprintf('(%s)', $e->getMessage()) : '')
+                )
+            );
+            return;
+        }
         try {
             $command = $this->getApplication()->find($scheduledCommand->getCommand());
         } catch (\InvalidArgumentException $e) {

--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -158,7 +158,6 @@ class ExecuteCommand extends ContainerAwareCommand
             }
 
             $scheduledCommand = $notLockedCommand;
-            sleep(20);
             $scheduledCommand->setLastExecution(new \DateTime());
             $scheduledCommand->setLocked(true);
             $scheduledCommand = $this->em->merge($scheduledCommand);

--- a/Entity/Repository/ScheduledCommandRepository.php
+++ b/Entity/Repository/ScheduledCommandRepository.php
@@ -2,6 +2,7 @@
 
 namespace JMose\CommandSchedulerBundle\Entity\Repository;
 
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\EntityRepository;
 use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
 
@@ -79,5 +80,22 @@ class ScheduledCommandRepository extends EntityRepository
         }
 
         return $failedCommands;
+    }
+
+    /**
+     * @param ScheduledCommand $command
+     * @return ScheduledCommand|null
+     */
+    public function getNotLockedCommand(ScheduledCommand $command)
+    {
+        $query = $this->createQueryBuilder('command')
+            ->where('command.locked = false')
+            ->andWhere('command.lastReturnCode = 0')
+            ->andWhere('command.id = :id')
+            ->setParameter('id', $command->getId())
+            ->getQuery();
+
+        $query->setLockMode(LockMode::PESSIMISTIC_WRITE);
+        return $query->getOneOrNullResult();
     }
 }


### PR DESCRIPTION
Related to this issue, i made a fix: https://github.com/J-Mose/CommandSchedulerBundle/issues/31

I couldn't make your testsuite run becauase of this:
FF...PHP Fatal error:  Call to a member function loadClass() on boolean in /Users/sandor/CommandSchedulerBundle/Tests/bootstrap.php on line 29

I don't think its related to my changed.

Please give me some instructions if you know what causes the issue.
