### PR TITLE
Update to services.yml for deprecation

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
         class: JMose\CommandSchedulerBundle\Service\CommandParser
         arguments:
             - "@kernel"
-            - %jmose_command_scheduler.excluded_command_namespaces%
+            - "%jmose_command_scheduler.excluded_command_namespaces%"
 
     jmose_command_scheduler.form.type.command_choice:
         class: JMose\CommandSchedulerBundle\Form\Type\CommandChoiceType


### PR DESCRIPTION
The newer YAML component deprecates using unquoted scalars that start with a `%`.

All I have done is quote the `%jmose_command_scheduler.excluded_command_namespaces%` argument in the `services.yml` file to remove the deprecation warning from Symfony.