### PR TITLE
Argument parsing enhance

### DIFF
--- a/Entity/ScheduledCommand.php
+++ b/Entity/ScheduledCommand.php
@@ -172,15 +172,22 @@ class ScheduledCommand
             preg_match_all('/((?:[^ "\']|"[^"]*"|\'[^\']*\')+)/', $this->arguments, $flatArgsArray);
 
             foreach ($flatArgsArray[0] as $argument) {
-                if (preg_match_all('/(.*?)=(?:["\'](.*)["\']|(.*))/', $argument, $tmpArray) === 0) {
+				if (preg_match_all('/(.*?)=(?:"(.*)"|\'(.*)\'|(.*))/', $argument, $tmpArray) === 0) {
                     $argsArray[$argument] = true;
-                } else if($tmpArray[2][0]) {
-                    $argsArray[$tmpArray[1][0]] = $tmpArray[2][0];
-                } else if($tmpArray[3][0]) {
-                    $argsArray[$tmpArray[1][0]] = $tmpArray[3][0];
-                } else {
-                    $argsArray[$tmpArray[1][0]] = "";
+					continue;
                 }
+				
+				$argument_name = $tmpArray[1][0];
+				$argument_value = max($tmpArray[2][0], $tmpArray[3][0], $tmpArray[4][0]);
+				
+				if(array_key_exists($argument_name, $argsArray)) {
+					if(!is_array($argsArray[$argument_name])) {
+						$argsArray[$argument_name] = array($argsArray[$argument_name]);
+					}
+					$argsArray[$argument_name][] = $argument_value;
+				} else {
+					$argsArray[$argument_name] = $argument_value;
+				}
             }
         }
         return $argsArray;

--- a/Entity/ScheduledCommand.php
+++ b/Entity/ScheduledCommand.php
@@ -172,22 +172,22 @@ class ScheduledCommand
             preg_match_all('/((?:[^ "\']|"[^"]*"|\'[^\']*\')+)/', $this->arguments, $flatArgsArray);
 
             foreach ($flatArgsArray[0] as $argument) {
-				if (preg_match_all('/(.*?)=(?:"(.*)"|\'(.*)\'|(.*))/', $argument, $tmpArray) === 0) {
-                    $argsArray[$argument] = true;
-					continue;
+	        if (preg_match_all('/(.*?)=(?:"(.*)"|\'(.*)\'|(.*))/', $argument, $tmpArray) === 0) {
+		    $argsArray[$argument] = true;
+		    continue;
                 }
 				
-				$argument_name = $tmpArray[1][0];
-				$argument_value = max($tmpArray[2][0], $tmpArray[3][0], $tmpArray[4][0]);
-				
-				if(array_key_exists($argument_name, $argsArray)) {
-					if(!is_array($argsArray[$argument_name])) {
-						$argsArray[$argument_name] = array($argsArray[$argument_name]);
-					}
-					$argsArray[$argument_name][] = $argument_value;
-				} else {
-					$argsArray[$argument_name] = $argument_value;
-				}
+		$argument_name = $tmpArray[1][0];
+		$argument_value = max($tmpArray[2][0], $tmpArray[3][0], $tmpArray[4][0]);
+
+		if(array_key_exists($argument_name, $argsArray)) {
+		   if(!is_array($argsArray[$argument_name])) {
+			$argsArray[$argument_name] = array($argsArray[$argument_name]);
+		    }
+		    $argsArray[$argument_name][] = $argument_value;
+		} else {
+		    $argsArray[$argument_name] = $argument_value;
+		}
             }
         }
         return $argsArray;

--- a/Tests/Entity/ScheduledCommandTest.php
+++ b/Tests/Entity/ScheduledCommandTest.php
@@ -12,17 +12,30 @@ use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
 class ScheduledCommandTest extends WebTestCase
 {
 
-    /**
-     * Test CommandScheduler parameters parsing
+	/**
+     * Test CommandScheduler parameters parsing with no quotes
      */
-    public function testParametersParsing()
+    public function testNoQuotesParametersParsing()
     {
 		$scheduledCommand = new ScheduledCommand();
 		
-		$scheduledCommand->setArguments("argument1='my new value'");
+		$scheduledCommand->setArguments("argument5=value");
 		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument1', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument1'], 'my new value');
+		$this->assertArrayHasKey('argument5', $parsedArguments);
+		$this->assertEquals($parsedArguments['argument5'], 'value');
+		
+		$scheduledCommand->setArguments("argument5=wrong value");
+		$parsedArguments = $scheduledCommand->getArguments(true);
+		$this->assertArrayHasKey('argument5', $parsedArguments);
+		$this->assertNotEquals($parsedArguments['argument5'], 'wrong value');
+	}
+
+    /**
+     * Test CommandScheduler parameters parsing with double quotes
+     */
+    public function testDoubleQuotesParametersParsing()
+    {
+		$scheduledCommand = new ScheduledCommand();
 		
 		$scheduledCommand->setArguments("argument2=\"my new value\"");
 		$parsedArguments = $scheduledCommand->getArguments(true);
@@ -34,26 +47,6 @@ class ScheduledCommandTest extends WebTestCase
 		$this->assertArrayHasKey('argument3', $parsedArguments);
 		$this->assertEquals($parsedArguments['argument3'], "my new ' value");
 		
-		$scheduledCommand->setArguments("argument4='my new \" value'");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument4', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument4'], 'my new " value');
-		
-		$scheduledCommand->setArguments("argument5=value");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument5', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument5'], 'value');
-		
-		$scheduledCommand->setArguments("argument5=wrong value");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument5', $parsedArguments);
-		$this->assertNotEquals($parsedArguments['argument5'], 'wrong value');
-		
-        $scheduledCommand->setArguments("--option1='my new value'");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--option1', $parsedArguments);
-		$this->assertEquals($parsedArguments['--option1'], 'my new value');
-		
 		$scheduledCommand->setArguments("--option2=\"my new value\"");
 		$parsedArguments = $scheduledCommand->getArguments(true);
 		$this->assertArrayHasKey('--option2', $parsedArguments);
@@ -64,22 +57,73 @@ class ScheduledCommandTest extends WebTestCase
 		$this->assertArrayHasKey('--option3', $parsedArguments);
 		$this->assertEquals($parsedArguments['--option3'], "my new ' value");
 		
+		//Wrong value
+		$scheduledCommand->setArguments("argument=\"my bad value'");
+		$parsedArguments = $scheduledCommand->getArguments(true);
+		$this->assertArrayHasKey('argument', $parsedArguments);
+		$this->assertNotEquals($parsedArguments['argument'], 'my bad value');
+    }
+	
+	/**
+     * Test CommandScheduler parameters parsing with single quotes
+     */
+    public function testSingleQuotesParametersParsing()
+    {
+		$scheduledCommand = new ScheduledCommand();
+		
+		$scheduledCommand->setArguments("argument1='my new value'");
+		$parsedArguments = $scheduledCommand->getArguments(true);
+		$this->assertArrayHasKey('argument1', $parsedArguments);
+		$this->assertEquals($parsedArguments['argument1'], 'my new value');
+		
+		$scheduledCommand->setArguments("argument4='my new \" value'");
+		$parsedArguments = $scheduledCommand->getArguments(true);
+		$this->assertArrayHasKey('argument4', $parsedArguments);
+		$this->assertEquals($parsedArguments['argument4'], 'my new " value');
+		
+        $scheduledCommand->setArguments("--option1='my new value'");
+		$parsedArguments = $scheduledCommand->getArguments(true);
+		$this->assertArrayHasKey('--option1', $parsedArguments);
+		$this->assertEquals($parsedArguments['--option1'], 'my new value');
+		
 		$scheduledCommand->setArguments("--option4='my new \" value'");
 		$parsedArguments = $scheduledCommand->getArguments(true);
 		$this->assertArrayHasKey('--option4', $parsedArguments);
 		$this->assertEquals($parsedArguments['--option4'], 'my new " value');
 		
-		$scheduledCommand->setArguments("--option5=value");
+		//Wrong value
+		$scheduledCommand->setArguments("argument='my bad value\"");
 		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--option5', $parsedArguments);
-		$this->assertEquals($parsedArguments['--option5'], 'value');
+		$this->assertArrayHasKey('argument', $parsedArguments);
+		$this->assertNotEquals($parsedArguments['argument'], 'my bad value');
+    }
+	
+	/**
+     * Test CommandScheduler array parameters parsing with single quotes
+     */
+    public function testArrayParametersParsing()
+    {
+		$scheduledCommand = new ScheduledCommand();
 		
-		$scheduledCommand->setArguments("--option5=wrong value");
+		$scheduledCommand->setArguments("--array-option=value1 --array-option='long value' --array-option=\"other long value\"");
 		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--option5', $parsedArguments);
-		$this->assertNotEquals($parsedArguments['--option5'], 'wrong value');
 		
-		$scheduledCommand->setArguments("--flag");
+		$this->assertArrayHasKey('--array-option', $parsedArguments);
+		$this->assertInternalType('array', $parsedArguments['--array-option']);
+		$this->assertEquals(3, count($parsedArguments['--array-option']));
+		$this->assertContains("value1", $parsedArguments['--array-option']);
+		$this->assertContains("long value", $parsedArguments['--array-option']);
+		$this->assertContains("other long value", $parsedArguments['--array-option']);
+    }
+	
+	/**
+     * Test CommandScheduler flag parameters parsing
+     */
+    public function testFlagParametersParsing()
+    {
+		$scheduledCommand = new ScheduledCommand();
+		
+        $scheduledCommand->setArguments("--flag");
 		$parsedArguments = $scheduledCommand->getArguments(true);
 		$this->assertArrayHasKey('--flag', $parsedArguments);
 		$this->assertEquals($parsedArguments['--flag'], true);

--- a/Tests/Entity/ScheduledCommandTest.php
+++ b/Tests/Entity/ScheduledCommandTest.php
@@ -9,123 +9,118 @@ use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
  * Class ScheduledCommandTest
  * @package JMose\CommandSchedulerBundle\Tests\Entity
  */
-class ScheduledCommandTest extends WebTestCase
-{
+class ScheduledCommandTest extends WebTestCase {
 
-	/**
+    /**
      * Test CommandScheduler parameters parsing with no quotes
      */
-    public function testNoQuotesParametersParsing()
-    {
-		$scheduledCommand = new ScheduledCommand();
-		
-		$scheduledCommand->setArguments("argument5=value");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument5', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument5'], 'value');
-		
-		$scheduledCommand->setArguments("argument5=wrong value");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument5', $parsedArguments);
-		$this->assertNotEquals($parsedArguments['argument5'], 'wrong value');
-	}
+    public function testNoQuotesParametersParsing() {
+        $scheduledCommand = new ScheduledCommand();
+
+        $scheduledCommand->setArguments("argument5=value");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument5', $parsedArguments);
+        $this->assertEquals($parsedArguments['argument5'], 'value');
+
+        $scheduledCommand->setArguments("argument5=wrong value");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument5', $parsedArguments);
+        $this->assertNotEquals($parsedArguments['argument5'], 'wrong value');
+    }
 
     /**
      * Test CommandScheduler parameters parsing with double quotes
      */
-    public function testDoubleQuotesParametersParsing()
-    {
-		$scheduledCommand = new ScheduledCommand();
-		
-		$scheduledCommand->setArguments("argument2=\"my new value\"");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument2', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument2'], 'my new value');
-		
-		$scheduledCommand->setArguments("argument3=\"my new ' value\"");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument3', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument3'], "my new ' value");
-		
-		$scheduledCommand->setArguments("--option2=\"my new value\"");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--option2', $parsedArguments);
-		$this->assertEquals($parsedArguments['--option2'], 'my new value');
-		
-		$scheduledCommand->setArguments("--option3=\"my new ' value\"");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--option3', $parsedArguments);
-		$this->assertEquals($parsedArguments['--option3'], "my new ' value");
-		
-		//Wrong value
-		$scheduledCommand->setArguments("argument=\"my bad value'");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument', $parsedArguments);
-		$this->assertNotEquals($parsedArguments['argument'], 'my bad value');
+    public function testDoubleQuotesParametersParsing() {
+        $scheduledCommand = new ScheduledCommand();
+
+        $scheduledCommand->setArguments("argument2=\"my new value\"");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument2', $parsedArguments);
+        $this->assertEquals($parsedArguments['argument2'], 'my new value');
+
+        $scheduledCommand->setArguments("argument3=\"my new ' value\"");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument3', $parsedArguments);
+        $this->assertEquals($parsedArguments['argument3'], "my new ' value");
+
+        $scheduledCommand->setArguments("--option2=\"my new value\"");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('--option2', $parsedArguments);
+        $this->assertEquals($parsedArguments['--option2'], 'my new value');
+
+        $scheduledCommand->setArguments("--option3=\"my new ' value\"");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('--option3', $parsedArguments);
+        $this->assertEquals($parsedArguments['--option3'], "my new ' value");
+
+        //Wrong value
+        $scheduledCommand->setArguments("argument=\"my bad value'");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument', $parsedArguments);
+        $this->assertNotEquals($parsedArguments['argument'], 'my bad value');
     }
-	
-	/**
+
+    /**
      * Test CommandScheduler parameters parsing with single quotes
      */
-    public function testSingleQuotesParametersParsing()
-    {
-		$scheduledCommand = new ScheduledCommand();
-		
-		$scheduledCommand->setArguments("argument1='my new value'");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument1', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument1'], 'my new value');
-		
-		$scheduledCommand->setArguments("argument4='my new \" value'");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument4', $parsedArguments);
-		$this->assertEquals($parsedArguments['argument4'], 'my new " value');
-		
+    public function testSingleQuotesParametersParsing() {
+        $scheduledCommand = new ScheduledCommand();
+
+        $scheduledCommand->setArguments("argument1='my new value'");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument1', $parsedArguments);
+        $this->assertEquals($parsedArguments['argument1'], 'my new value');
+
+        $scheduledCommand->setArguments("argument4='my new \" value'");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument4', $parsedArguments);
+        $this->assertEquals($parsedArguments['argument4'], 'my new " value');
+
         $scheduledCommand->setArguments("--option1='my new value'");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--option1', $parsedArguments);
-		$this->assertEquals($parsedArguments['--option1'], 'my new value');
-		
-		$scheduledCommand->setArguments("--option4='my new \" value'");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--option4', $parsedArguments);
-		$this->assertEquals($parsedArguments['--option4'], 'my new " value');
-		
-		//Wrong value
-		$scheduledCommand->setArguments("argument='my bad value\"");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('argument', $parsedArguments);
-		$this->assertNotEquals($parsedArguments['argument'], 'my bad value');
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('--option1', $parsedArguments);
+        $this->assertEquals($parsedArguments['--option1'], 'my new value');
+
+        $scheduledCommand->setArguments("--option4='my new \" value'");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('--option4', $parsedArguments);
+        $this->assertEquals($parsedArguments['--option4'], 'my new " value');
+
+        //Wrong value
+        $scheduledCommand->setArguments("argument='my bad value\"");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('argument', $parsedArguments);
+        $this->assertNotEquals($parsedArguments['argument'], 'my bad value');
     }
-	
-	/**
+
+    /**
      * Test CommandScheduler array parameters parsing with single quotes
      */
-    public function testArrayParametersParsing()
-    {
-		$scheduledCommand = new ScheduledCommand();
-		
-		$scheduledCommand->setArguments("--array-option=value1 --array-option='long value' --array-option=\"other long value\"");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		
-		$this->assertArrayHasKey('--array-option', $parsedArguments);
-		$this->assertInternalType('array', $parsedArguments['--array-option']);
-		$this->assertEquals(3, count($parsedArguments['--array-option']));
-		$this->assertContains("value1", $parsedArguments['--array-option']);
-		$this->assertContains("long value", $parsedArguments['--array-option']);
-		$this->assertContains("other long value", $parsedArguments['--array-option']);
+    public function testArrayParametersParsing() {
+        $scheduledCommand = new ScheduledCommand();
+
+        $scheduledCommand->setArguments("--array-option=value1 --array-option='long value' --array-option=\"other long value\"");
+        $parsedArguments = $scheduledCommand->getArguments(true);
+
+        $this->assertArrayHasKey('--array-option', $parsedArguments);
+        $this->assertInternalType('array', $parsedArguments['--array-option']);
+        $this->assertEquals(3, count($parsedArguments['--array-option']));
+        $this->assertContains("value1", $parsedArguments['--array-option']);
+        $this->assertContains("long value", $parsedArguments['--array-option']);
+        $this->assertContains("other long value", $parsedArguments['--array-option']);
     }
-	
-	/**
+
+    /**
      * Test CommandScheduler flag parameters parsing
      */
-    public function testFlagParametersParsing()
-    {
-		$scheduledCommand = new ScheduledCommand();
-		
+    public function testFlagParametersParsing() {
+        $scheduledCommand = new ScheduledCommand();
+
         $scheduledCommand->setArguments("--flag");
-		$parsedArguments = $scheduledCommand->getArguments(true);
-		$this->assertArrayHasKey('--flag', $parsedArguments);
-		$this->assertEquals($parsedArguments['--flag'], true);
+        $parsedArguments = $scheduledCommand->getArguments(true);
+        $this->assertArrayHasKey('--flag', $parsedArguments);
+        $this->assertEquals($parsedArguments['--flag'], true);
     }
+
 }


### PR DESCRIPTION
Addresses issue #55. If the arguments passed to the scheduled command repeats (eg. `--arg1=a --arg1=b --arg1=c`) now the option called **--arg1** will be an array containing the repeated values (eg. `array("a", "b", "c"`).