### PR TITLE
updating dependencies to allow twig 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,27 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - nightly
     - hhvm
+
+env:
+ - SYMFONY_VERSION=2.8.*
+ - SYMFONY_VERSION=3.0.*
+ - SYMFONY_VERSION=3.1.*
+ - SYMFONY_VERSION=3.2.*
 
 branches:
     only:
         - master
         - /^\d+\.\d+$/
 
+#symfony 3.0 is no longer supported by symfony, allow it to fail
 matrix:
-    include:
-        - php: 5.5
-          env: SYMFONY_VERSION=2.8.*
     allow_failures:
         - php: nightly
+        - php: hhvm
+        - env: SYMFONY_VERSION=3.0.*
 
 before_script:
     - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.5.9",
         "symfony/symfony": "~2.7|~3.0",
         "sensio/framework-extra-bundle": "~2.3|~3.0",
-        "twig/twig": "~1.15",
+        "twig/twig": "~1.15|~2.0",
         "doctrine/orm": "~2.2,>=2.2.3,<2.6",
         "doctrine/doctrine-bundle": "~1.0",
         "mtdowling/cron-expression": "~1.0"


### PR DESCRIPTION
updating dependencies to allow twig 2.x, updating test matrix to allow symfony 3.0 to fail (unsuported version of symfony - twig 2.0 breaks on it)

resolves issue #66 