### PR TITLE
New Feature: ON-Demand Command Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 vendor/
+build/
+/nbproject/
+composer.lock

--- a/Entity/ScheduledCommand.php
+++ b/Entity/ScheduledCommand.php
@@ -59,6 +59,13 @@ class ScheduledCommand
      */
     private $priority;
 
+    const MODE_AUTO = 'auto';
+    const MODE_ONDEMAND = 'ondemand';
+    /**
+     * @var string
+     */
+    private $executionMode;
+    
     /**
      * If true, command will be execute next time regardless cron expression
      *
@@ -388,6 +395,16 @@ class ScheduledCommand
     {
         $this->locked = $locked;
 
+        return $this;
+    }
+    
+    public function getExecutionMode(){
+        return $this->executionMode;
+    }
+    
+    public function setExecutionMode($executionMode){
+        $this->executionMode = $executionMode;
+        
         return $this;
     }
 

--- a/Form/Type/ScheduledCommandType.php
+++ b/Form/Type/ScheduledCommandType.php
@@ -3,6 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -51,7 +52,7 @@ class ScheduledCommandType extends AbstractType
         $builder->add(
             'cronExpression', TextType::class, array(
                 'label' => 'detail.cronExpression',
-                'required' => true
+                'required' => false
             )
         );
 
@@ -70,6 +71,16 @@ class ScheduledCommandType extends AbstractType
             )
         );
 
+        $builder->add(
+            'executionMode', ChoiceType::class, array(
+                'label' => 'detail.executionMode',
+                'choices' => [
+                    'detail.executionMode.auto' => \JMose\CommandSchedulerBundle\Entity\ScheduledCommand::MODE_AUTO,
+                    'detail.executionMode.ondemand' => \JMose\CommandSchedulerBundle\Entity\ScheduledCommand::MODE_ONDEMAND
+                ]
+            )
+        );
+        
         $builder->add(
             'executeImmediately', CheckboxType::class, array(
                 'label' => 'detail.executeImmediately',

--- a/Resources/config/doctrine/ScheduledCommand.orm.yml
+++ b/Resources/config/doctrine/ScheduledCommand.orm.yml
@@ -62,6 +62,12 @@ JMose\CommandSchedulerBundle\Entity\ScheduledCommand:
             unique: false
             nullable: false
             column: PRIORITY
+        executionMode:
+            type: string
+            length: 50
+            unique: false
+            nullable: false
+            column: B_EXECUTION_MODE
         executeImmediately:
             type: boolean
             length: null

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,3 +11,9 @@ services:
             - "@jmose_command_scheduler.command_parser"
         tags:
             - { name: form.type, alias: command_choice }
+            
+    jmose_command_scheduler.scheduler:
+        class: JMose\CommandSchedulerBundle\Service\SchedulerService
+        shared: false
+        arguments: 
+            - "@doctrine"

--- a/Resources/config/validation.yml
+++ b/Resources/config/validation.yml
@@ -4,7 +4,6 @@ namespaces:
 JMose\CommandSchedulerBundle\Entity\ScheduledCommand:
     properties:
         cronExpression:
-            - NotBlank: ~
             - CommandSchedulerConstraints:CronExpression: { message: "commandScheduler.validation.cron" }
         name:
             - NotBlank: ~

--- a/Resources/translations/JMoseCommandScheduler.de.xlf
+++ b/Resources/translations/JMoseCommandScheduler.de.xlf
@@ -107,6 +107,18 @@
                 <source>detail.actions</source>
                 <target>Aktionen</target>
             </trans-unit>
+            <trans-unit id="214">
+                <source>detail.executionMode</source>
+                <target>Execution Mode</target>
+            </trans-unit>
+            <trans-unit id="215">
+                <source>detail.executionMode.auto</source>
+                <target>Cron Expression (Auto)</target>
+            </trans-unit>
+            <trans-unit id="216">
+                <source>detail.executionMode.ondemand</source>
+                <target>ON-Demand (Forced)</target>
+            </trans-unit>
 
             <!-- Flashs messages -->
             <trans-unit id="300">

--- a/Resources/translations/JMoseCommandScheduler.en.xlf
+++ b/Resources/translations/JMoseCommandScheduler.en.xlf
@@ -107,6 +107,18 @@
                 <source>detail.actions</source>
                 <target>Actions</target>
             </trans-unit>
+            <trans-unit id="214">
+                <source>detail.executionMode</source>
+                <target>Execution Mode</target>
+            </trans-unit>
+            <trans-unit id="215">
+                <source>detail.executionMode.auto</source>
+                <target>Cron Expression (Auto)</target>
+            </trans-unit>
+            <trans-unit id="216">
+                <source>detail.executionMode.ondemand</source>
+                <target>ON-Demand (Forced)</target>
+            </trans-unit>
 
             <!-- Flashs messages -->
             <trans-unit id="300">

--- a/Resources/translations/JMoseCommandScheduler.es.xlf
+++ b/Resources/translations/JMoseCommandScheduler.es.xlf
@@ -107,6 +107,18 @@
                 <source>detail.actions</source>
                 <target>Acciones</target>
             </trans-unit>
+            <trans-unit id="214">
+                <source>detail.executionMode</source>
+                <target>Execution Mode</target>
+            </trans-unit>
+            <trans-unit id="215">
+                <source>detail.executionMode.auto</source>
+                <target>Cron Expression (Auto)</target>
+            </trans-unit>
+            <trans-unit id="216">
+                <source>detail.executionMode.ondemand</source>
+                <target>ON-Demand (Forced)</target>
+            </trans-unit>
 
             <!-- Flashs messages -->
             <trans-unit id="300">

--- a/Resources/translations/JMoseCommandScheduler.fr.xlf
+++ b/Resources/translations/JMoseCommandScheduler.fr.xlf
@@ -104,6 +104,18 @@
                 <source>detail.actions</source>
                 <target>Actions</target>
             </trans-unit>
+            <trans-unit id="214">
+                <source>detail.executionMode</source>
+                <target>Execution Mode</target>
+            </trans-unit>
+            <trans-unit id="215">
+                <source>detail.executionMode.auto</source>
+                <target>Cron Expression (Auto)</target>
+            </trans-unit>
+            <trans-unit id="216">
+                <source>detail.executionMode.ondemand</source>
+                <target>ON-Demand (Forced)</target>
+            </trans-unit>
 
             <!-- Flashs messages -->
             <trans-unit id="300">

--- a/Resources/views/Detail/index.html.twig
+++ b/Resources/views/Detail/index.html.twig
@@ -14,6 +14,7 @@
         {# Form's fields #}
         {{ form_row( scheduledCommandForm.id ) }}
         {{ form_row( scheduledCommandForm.name, {'attr': styleConfiguration|merge({'placeholder': 'name'}) } ) }}
+        {{ form_row( scheduledCommandForm.executionMode, {'attr': styleConfiguration } ) }}
         {{ form_row( scheduledCommandForm.command, {'attr': styleConfiguration } ) }}
         {{ form_row( scheduledCommandForm.arguments, {'attr': styleConfiguration|merge({'placeholder': '--argument1=foo --bar'}) } ) }}
         {{ form_row( scheduledCommandForm.cronExpression, {'attr': styleConfiguration|merge({'placeholder': '*/10 * * * *'}) } ) }}

--- a/Service/SchedulerService.php
+++ b/Service/SchedulerService.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace JMose\CommandSchedulerBundle\Service;
+
+use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
+use Cron\CronExpression as CronExpressionLib;
+
+/**
+ * Provider simplified access to Schedule Commands (ON-Demand)
+ *
+ * @author Carlos Sosa
+ */
+class SchedulerService {
+    
+    /**
+     * @var \Doctrine\Bundle\DoctrineBundle\Registry
+     */
+    private $doctrine;
+    
+    /**
+     *
+     * @var string
+     */
+    private $commandName;
+    
+    /**
+     *
+     * @var ScheduledCommand
+     */
+    private $command;
+    
+    /**
+     * 
+     * @param \Doctrine\Bundle\DoctrineBundle\Registry $doctrine
+     */
+    public function __construct(\Doctrine\Bundle\DoctrineBundle\Registry $doctrine) { $this->doctrine = $doctrine; }
+    
+    /** Aliases */
+    public function command( $commandName) { return $this->cmd($commandName); }
+    public function get( $commandName) { return $this->cmd($commandName); }
+
+    /**
+     * 
+     * @param string $commandName
+     * @return SchedulerService
+     */
+    public function cmd( $commandName) {
+        $this->commandName = $commandName;
+        
+        return $this;
+    }
+    
+    public function exists()
+    {
+        try {            
+            if ( $this->getCommand() ) {
+                return true;
+            }
+            return false;
+        } catch (\Exception $ex) {
+            // TODO: Improve error handling            
+            return false;
+        }
+    }
+
+
+    /**
+     * Command Actions
+     */
+    public function run         () { return $this->commandAction('run'); }
+    public function stop        () { return $this->commandAction('stop'); }
+    public function disable     () { return $this->commandAction('disable'); }
+    public function enable      () { return $this->commandAction('enable'); }
+    public function setOndemand () { return $this->commandAction( ScheduledCommand::MODE_ONDEMAND); }
+    public function setAuto     () { return $this->commandAction( ScheduledCommand::MODE_AUTO); }
+    
+    /**
+     * Command Statuses
+     */
+    public function isFailing  () { return $this->commandStatus('failing'); }
+    public function isRunning  () { return $this->commandStatus('running'); }
+    public function isStopped  () { return $this->commandStatus('stopped'); }
+    public function isDisabled () { return $this->commandStatus('disabled'); }
+    public function isEnabled  () { return $this->commandStatus('enabled'); }
+    public function isOndemand () { return $this->commandStatus( ScheduledCommand::MODE_ONDEMAND); }
+    public function istAuto    () { return $this->commandStatus( ScheduledCommand::MODE_AUTO); }
+    
+    /**
+     * 
+     * @param string $commandName
+     * @return ScheduledCommand
+     * @throws \ErrorException
+     */
+    private function getCommand ( ) : ScheduledCommand {
+        if ( $this->command) {
+            return $this->command;
+        }
+        
+        if ( !$this->commandName ){
+            throw new \ErrorException('Missing Command Name.');
+        }
+        
+        $cmd = $this->doctrine->getRepository(ScheduledCommand::class)->findOneBy([
+                    'name' => $this->commandName
+                ]);
+        
+        if ( $cmd instanceof ScheduledCommand) {
+            return $cmd;
+        }
+        
+        throw new \ErrorException('Command Not Found.');
+    }
+
+
+    /**
+     * Schedule command to be executed in the next execution cycle
+     * 
+     * @param string $action
+     */
+    private function commandAction ( string $action ){
+        try {            
+            $cmd = $this->getCommand();
+
+            switch ( $action ){
+                case 'run': $cmd->setExecuteImmediately(true); break;
+                case 'stop': $cmd->setExecuteImmediately(false); break;
+                case 'disable': $cmd->setDisabled(true); break;
+                case 'enable': $cmd->setDisabled(false); break;
+                case ScheduledCommand::MODE_ONDEMAND: $cmd->setExecutionMode( ScheduledCommand::MODE_ONDEMAND); break;
+                case ScheduledCommand::MODE_AUTO: 
+                    if ( CronExpressionLib::isValidExpression( $cmd->getCronExpression()) ) {
+                        $cmd->setExecutionMode( ScheduledCommand::MODE_AUTO); 
+                    } else {
+                        throw new \InvalidArgumentException('Invalid Cron Expression.');
+                    }
+                    break;
+            }
+            $this->doctrine->getManager()->persist($cmd);
+            $this->doctrine->getManager()->flush($cmd);
+
+            return true;
+        } catch (\Exception $ex) {// TODO: Improve error handling            
+            return false;
+        }
+    }
+    
+    private function commandStatus ( string $status ){
+        try {            
+            $cmd = $this->getCommand();
+
+            switch ( $status ){
+                case 'failing': return ( $cmd->getLastReturnCode() == -1 ); 
+                case 'running': return ( $cmd->isLocked() || $cmd->getExecuteImmediately()); 
+                case 'stopped': return ( ! $cmd->isLocked() && ! $cmd->getExecuteImmediately()); 
+                case 'enabled': return ( ! $cmd->isDisabled());
+                case 'disabled': return $cmd->isDisabled();
+                case ScheduledCommand::MODE_ONDEMAND: ( $cmd->setExecutionMode() == ScheduledCommand::MODE_ONDEMAND);
+                case ScheduledCommand::MODE_AUTO: ( $cmd->setExecutionMode() == ScheduledCommand::MODE_AUTO);
+            }
+            
+            return false;
+        } catch (\Exception $ex) {
+            // TODO: Improve error handling            
+            return false;
+        }
+    }
+}

--- a/Tests/Controller/DetailControllerTest.php
+++ b/Tests/Controller/DetailControllerTest.php
@@ -42,6 +42,7 @@ class DetailControllerTest extends WebTestCase
         $fixtureSet = array(
             'command_scheduler_detail[id]' => "1",
             'command_scheduler_detail[name]' => "one",
+            'command_scheduler_detail[executionMode]' => "auto",
             'command_scheduler_detail[command]' => "debug:container",
             'command_scheduler_detail[arguments]' => "--help",
             'command_scheduler_detail[cronExpression]' => "@daily",
@@ -67,6 +68,7 @@ class DetailControllerTest extends WebTestCase
 
         $form->setValues(array(
             'command_scheduler_detail[name]' => "wtc",
+            'command_scheduler_detail[executionMode]' => "auto",
             'command_scheduler_detail[command]' => "translation:update",
             'command_scheduler_detail[arguments]' => "--help",
             'command_scheduler_detail[cronExpression]' => "@daily",

--- a/Validator/Constraints/CronExpressionValidator.php
+++ b/Validator/Constraints/CronExpressionValidator.php
@@ -24,10 +24,14 @@ class CronExpressionValidator extends ConstraintValidator
     {
         $value = (string)$value;
 
-        if (null === $value || '' === $value) {
-            return;
+        if ( $this->context->getObject()->getExecutionMode() == \JMose\CommandSchedulerBundle\Entity\ScheduledCommand::MODE_ONDEMAND ){
+            return ;
         }
-
+        
+        if (null === $value || '' === $value) {
+            $this->context->addViolation($constraint->message, array(), $value);
+        }
+        
         try {
             CronExpressionLib::factory($value);
         } catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
- **ON-Demand Command Support:** Allow commands to exist for the sole purpose of being executed on demand and not by Cron Schedule, those command will be executed using executeImmediately only.

- **Scheduler Service:** A simplified way to Control Commands and queue On-Demand Commands.

```
$svc = $this->getContainer()->get('jmose_command_scheduler.scheduler')->cmd('command-name');
        
if ( $svc->isStopped() ){
     $svc->run();
}
```
