### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jmose/command-scheduler-bundle",
-    "description": "This Symfony2 bundle will allow you to schedule all your commands just like UNIX crontab",
+    "description": "This Symfony bundle will allow you to schedule all your commands just like UNIX crontab",
     "keywords": ["Symfony", "scheduler", "cron", "command", "task"],
     "homepage": "https://github.com/J-Mose/CommandSchedulerBundle",
     "type": "symfony-bundle",
@@ -13,18 +13,18 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/symfony": "~2.7|~3.0",
-        "sensio/framework-extra-bundle": "~2.3|~3.0",
+        "symfony/symfony": "~2.8|~3.0",
+        "sensio/framework-extra-bundle": "^3.0.2",
         "twig/twig": "~1.15|~2.0",
-        "doctrine/orm": "~2.2,>=2.2.3,<2.6",
-        "doctrine/doctrine-bundle": "~1.0",
-        "mtdowling/cron-expression": "~1.0"
+        "doctrine/orm": "^2.4.8|^2.5",
+        "doctrine/doctrine-bundle": "^1.4|^1.6",
+        "mtdowling/cron-expression": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4",
-        "satooshi/php-coveralls": "~0.6",
-        "doctrine/doctrine-fixtures-bundle": "~2.2",
-        "liip/functional-test-bundle": "1.2.2|~1.3"
+        "phpunit/phpunit": "~4.8",
+        "satooshi/php-coveralls": "~1.0",
+        "doctrine/doctrine-fixtures-bundle": "~2.4",
+        "liip/functional-test-bundle": "^1.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I updated all the dependencies to versions that support php 5.5.9 or Symfony 2.8

- `"symfony/symfony": "~2.8|~3.0"` - min supported symfony version is 2.8
- `"sensio/framework-extra-bundle": "^3.0.2"` - requres from default composer.json Symfony 2.8 and 3.0
- `"doctrine/orm": "^2.4.8|^2.5"` - requres from default composer.json Symfony 2.8 and 3.0
- `"doctrine/doctrine-bundle": "^1.4|^1.6"` - requres from default composer.json Symfony 2.8 and 3.0
- `"mtdowling/cron-expression": "^1.2"` - last stable version. no bc changes.
- 
- `"phpunit/phpunit": "~4.8"` - last version that support php 5.5.9
- `"satooshi/php-coveralls": "~1.0"` - last stable version. no bc changes.
- `"doctrine/doctrine-fixtures-bundle": "~2.4"` - last stable version. no bc changes.
- `"liip/functional-test-bundle": "^1.6"` - last version that support php 5.5.9

---
real updates on my system (php 7.1) after this changes:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating satooshi/php-coveralls (v0.7.1 => v1.0.1): Loading from cache
Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
Writing lock file
Generating autoload files

Process finished with exit code 0 at 08:49:56.
Execution time: 19 732 ms.
```