### PR TITLE
Add a command to unlock a single or all locked scheduled commands

### DIFF
--- a/Command/UnlockCommand.php
+++ b/Command/UnlockCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace JMose\CommandSchedulerBundle\Command;
+
+use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command to unlock one or all scheduled commands that have surpassed the lock timeout
+ *
+ * @author  Marcel Pfeiffer <m.pfeiffer@strucnamics.de>
+ * @package JMose\CommandSchedulerBundle\Command
+ */
+class UnlockCommand extends ContainerAwareCommand {
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    /**
+     * @var integer|boolean Number of seconds after a command is considered as timeout
+     */
+    private $lockTimeout;
+
+    /**
+     * @var bool true if all locked commands should be unlocked
+     */
+    private $unlockAll;
+
+    /**
+     * @var string name of the command to be unlocked
+     */
+    private $scheduledCommandName = [];
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure() {
+        $this
+                ->setName('scheduler:unlock')
+                ->setDescription('Unlock one or all scheduled commands that have surpassed the lock timeout.')
+                ->addArgument('name', InputArgument::OPTIONAL, 'Name of the command to unlock')
+                ->addOption('all', 'A', InputOption::VALUE_NONE, 'Unlock all scheduled commands')
+                ->addOption('lock-timeout', null, InputOption::VALUE_REQUIRED, 'Use this lock timeout value instead of the configured one (in seconds, optional)')
+        ;
+    }
+
+    /**
+     * Initialize parameters and services used in execute function
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output) {
+        $this->unlockAll = $input->getOption('all');
+        $this->scheduledCommandName = $input->getArgument('name');
+
+        $this->lockTimeout = $input->getOption('lock-timeout', null);
+        if ($this->lockTimeout === null) {
+            $this->lockTimeout = $this->getContainer()->getParameter('jmose_command_scheduler.lock_timeout');
+        } else if ($this->lockTimeout === 'false') {
+            $this->lockTimeout = false;
+        }
+
+        $this->em = $this->getContainer()->get('doctrine')->getManager(
+                $this->getContainer()->getParameter('jmose_command_scheduler.doctrine_manager')
+        );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output) {
+        if ($this->unlockAll === false && $this->scheduledCommandName === '') {
+            $output->writeln('Either the name of a scheduled command or the --all option must be set.');
+            return 1;
+        }
+
+        $repository = $this->em->getRepository(ScheduledCommand::class);
+
+        if ($this->unlockAll === true) {
+            $failedCommands = $repository->findLockedCommand();
+            foreach ($failedCommands as $failedCommand) {
+                $this->unlock($failedCommand, $output);
+            }
+        } else {
+            $scheduledCommand = $repository->findOneBy(['name' => $this->scheduledCommandName, 'disabled' => false]);
+            if ($scheduledCommand === null) {
+                $output->writeln(sprintf('Error: Scheduled Command with name "%s" not found or is disabled.', $this->scheduledCommandName));
+                return 1;
+            }
+            $this->unlock($scheduledCommand, $output);
+        }
+
+        $this->em->flush();
+
+        return 0;
+    }
+
+    /**
+     * @param ScheduledCommand $command command to be unlocked
+     * @return bool true if unlock happened
+     */
+    protected function unlock(ScheduledCommand $command, OutputInterface $output) {
+        if ($command->isLocked() === false) {
+            $output->writeln(sprintf('Skipping: Scheduled Command "%s" is not locked.', $command->getName()));
+            return false;
+        }
+
+        if ($this->lockTimeout !== false &&
+                $command->getLastExecution() !== null &&
+                $command->getLastExecution() >= (new \DateTime())->sub(new \DateInterval(sprintf('PT%dS', $this->lockTimeout)))) {
+            $output->writeln(sprintf('Skipping: Timout for scheduled Command "%s" has not run out.', $command->getName()));
+            return false;
+        }
+        $command->setLocked(false);
+        $output->writeln(sprintf('Scheduled Command "%s" has been unlocked.', $command->getName()));
+        return true;
+    }
+
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,3 +11,7 @@ services:
             - "@jmose_command_scheduler.command_parser"
         tags:
             - { name: form.type, alias: command_choice }
+
+    JMose\CommandSchedulerBundle\Command\UnlockCommand:
+        tags:
+            - { name: 'console.command' }

--- a/Tests/Command/UnlockCommandTest.php
+++ b/Tests/Command/UnlockCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace JMose\CommandSchedulerBundle\Tests\Command;
+
+use JMose\CommandSchedulerBundle\Entity\ScheduledCommand;
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+/**
+ * Class UnlockCommandTest
+ * @package JMose\CommandSchedulerBundle\Tests\Command
+ */
+class UnlockCommandTest extends WebTestCase {
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp() {
+        self::bootKernel();
+
+        $this->em = static::$kernel->getContainer()
+                ->get('doctrine')
+                ->getManager();
+    }
+
+    /**
+     * Test scheduler:unlock without --all option
+     */
+    public function testUnlockAll() {
+        //DataFixtures create 4 records
+        $this->loadFixtures(
+                ['JMose\CommandSchedulerBundle\Fixtures\ORM\LoadScheduledCommandData']
+        );
+
+        // One command is locked in fixture (2), another have a -1 return code as lastReturn (4)
+        $output = $this->runCommand(
+                'scheduler:unlock', ['--all' => true]
+        );
+
+        $this->assertRegExp('/"two"/', $output);
+        $this->assertNotRegExp('/"one"/', $output);
+        $this->assertNotRegExp('/"three"/', $output);
+
+        $this->em->clear();
+        $two = $this->em->getRepository(ScheduledCommand::class)->findOneBy(['name' => 'two']);
+
+        $this->assertFalse($two->isLocked());
+    }
+
+    /**
+     * Test scheduler:unlock with given command name
+     */
+    public function testUnlockByName() {
+        //DataFixtures create 4 records
+        $this->loadFixtures(
+                ['JMose\CommandSchedulerBundle\Fixtures\ORM\LoadScheduledCommandData']
+        );
+
+        // One command is locked in fixture (2), another have a -1 return code as lastReturn (4)
+        $output = $this->runCommand(
+                'scheduler:unlock', ['name' => 'two']
+        );
+
+        $this->assertRegExp('/"two"/', $output);
+
+        $this->em->clear();
+        $two = $this->em->getRepository(ScheduledCommand::class)->findOneBy(['name' => 'two']);
+
+        $this->assertFalse($two->isLocked());
+    }
+
+    /**
+     * Test scheduler:unlock with given command name and timeout
+     */
+    public function testUnlockByNameWithTimout() {
+        //DataFixtures create 4 records
+        $this->loadFixtures(
+                ['JMose\CommandSchedulerBundle\Fixtures\ORM\LoadScheduledCommandData']
+        );
+
+        // One command is locked in fixture with last execution two days ago (2), another have a -1 return code as lastReturn (4)
+        $output = $this->runCommand(
+                'scheduler:unlock', ['name' => 'two', '--lock-timeout' =>  2 * 24 * 60 * 60 + 2]
+        );
+
+        $this->assertRegExp('/Skipping/', $output);
+        $this->assertRegExp('/"two"/', $output);
+
+        $this->em->clear();
+        $two = $this->em->getRepository(ScheduledCommand::class)->findOneBy(['name' => 'two']);
+
+        $this->assertTrue($two->isLocked());
+    }
+
+}


### PR DESCRIPTION
At some of our installations we have not complete control about servers restarting. I created this command to unlock all scheduled commands at the boot of the server because those that were cancelled by a shutdown would stay locked.

The command is capable of handling all or a single scheduled command and takes the lock timeout into consideration. It's also possible to override the configured lock timeout.