### PR TITLE
Update to 3.4/4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor/
+composer.lock
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,13 @@
 language: php
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
+    - 7.2
     - nightly
-    - hhvm
 
 env:
- - SYMFONY_VERSION=2.8.*
- - SYMFONY_VERSION=3.0.*
- - SYMFONY_VERSION=3.1.*
- - SYMFONY_VERSION=3.2.*
- - SYMFONY_VERSION=3.3.*
  - SYMFONY_VERSION=3.4.*
+ - SYMFONY_VERSION=4.0.*
 
 branches:
     only:
@@ -25,8 +18,6 @@ branches:
 matrix:
     allow_failures:
         - php: nightly
-        - php: hhvm
-        - env: SYMFONY_VERSION=3.0.*
 
 before_script:
     - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -42,5 +33,5 @@ script:
 after_success: |
  sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" -a "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;'
 
-notifications:
-    email: julienguyon@hotmail.com
+#notifications:
+#    email: julienguyon@hotmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 branches:
     only:
         - master
+        - update-to-3-4
         - /^\d+\.\d+$/
 
 #symfony 3.0 is no longer supported by symfony, allow it to fail

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 
 php:
+    - 5.6	
+    - 7.0
     - 7.1
     - 7.2
     - nightly

--- a/JMoseCommandSchedulerBundle.php
+++ b/JMoseCommandSchedulerBundle.php
@@ -11,8 +11,10 @@ class JMoseCommandSchedulerBundle extends Bundle
      * {@inheritdoc}
      * @return JMoseCommandSchedulerExtension
      */
-    public function getContainerExtension() {
+    public function getContainerExtension()
+    {
         $class = $this->getContainerExtensionClass();
+
         return new $class;
     }
 
@@ -21,6 +23,6 @@ class JMoseCommandSchedulerBundle extends Bundle
      */
     protected function getContainerExtensionClass()
     {
-        return 'JMose\CommandSchedulerBundle\DependencyInjection\JMoseCommandSchedulerExtension';
+        return JMoseCommandSchedulerExtension::class;
     }
 }

--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ CommandSchedulerBundle
 
 This bundle will allow you to easily manage scheduling for Symfony's console commands (native or not) with cron expression.
 
-**Version**: 1.2.7  
+**Version**: 2.0
 
 **Compatibility**:
- - **Symfony 2.8** and **3.x**
+ - **Symfony 3.4** and **4.0**
  - Tested with PHP 5.5, 5.6, 7.0, 7.1
  - Doctrine ORM
-
-**If you use an older version of Symfony (2.3 to 2.7), use the last 1.1.x release**
 
 ## Features
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,3 +11,11 @@ services:
             - "@jmose_command_scheduler.command_parser"
         tags:
             - { name: form.type, alias: command_choice }
+
+    jmose_command_scheduler.execute_command:
+        class: JMose\CommandSchedulerBundle\Command\ExecuteCommand
+        tags: [console.command]
+
+    jmose_command_scheduler.monitor_command:
+        class: JMose\CommandSchedulerBundle\Command\MonitorCommand
+        tags: [console.command]

--- a/Tests/App/AppKernel.php
+++ b/Tests/App/AppKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Tests\App;
+
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Debug\ErrorHandler;
@@ -9,15 +11,14 @@ class AppKernel extends Kernel
     public function registerBundles()
     {
         return array(
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
-            new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-            new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
-            new Liip\FunctionalTestBundle\LiipFunctionalTestBundle(),
-
-            new JMose\CommandSchedulerBundle\JMoseCommandSchedulerBundle(),
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            new \Symfony\Bundle\TwigBundle\TwigBundle(),
+            new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+            new \Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
+            new \Liip\FunctionalTestBundle\LiipFunctionalTestBundle(),
+            new \JMose\CommandSchedulerBundle\JMoseCommandSchedulerBundle(),
         );
     }
 

--- a/Tests/App/config/config_test.yml
+++ b/Tests/App/config/config_test.yml
@@ -1,5 +1,5 @@
 parameters:
-    database_path: %kernel.root_dir%/../../build/test.db
+    database_path: "%kernel.root_dir%/../../build/test.db"
 
 framework:
     translator:      ~
@@ -20,7 +20,7 @@ doctrine:
         dbname:   jmose_command_scheduler_test
         user:     root
         charset:  UTF8
-        path:     %database_path%
+        path:     "%database_path%"
     orm:
         auto_generate_proxy_classes: true
         auto_mapping: true
@@ -35,7 +35,7 @@ security:
              memory: ~
 
 jmose_command_scheduler:
-    log_path: %kernel.root_dir%/logs/
+    log_path: "%kernel.root_dir%/logs/"
     lock_timeout: 300
     excluded_command_namespaces:
         - scheduler

--- a/Tests/App/console
+++ b/Tests/App/console
@@ -18,6 +18,6 @@ use Symfony\Component\Debug\Debug;
 $input = new ArgvInput();
 Debug::enable();
 
-$kernel = new AppKernel('test', true);
+$kernel = new \App\Tests\App\AppKernel('test', true);
 $application = new Application($kernel);
 $application->run($input);

--- a/Tests/DependencyInjection/JMoseCommandSchedulerExtensionTest.php
+++ b/Tests/DependencyInjection/JMoseCommandSchedulerExtensionTest.php
@@ -3,10 +3,11 @@
 namespace JMose\CommandSchedulerBundle\DependencyInjection\Tests;
 
 use JMose\CommandSchedulerBundle\DependencyInjection\JMoseCommandSchedulerExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
 
-class JMoseCommandSchedulerExtensionTest extends \PHPUnit_Framework_TestCase
+class JMoseCommandSchedulerExtensionTest extends TestCase
 {
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.8",
+        "php": "^5.6|>=7.0.8",
         "symfony/framework-bundle": "^3.4|^4.0",
         "symfony/console": "^3.4|^4.0",
         "sensio/framework-extra-bundle": "^5.1.0",

--- a/composer.json
+++ b/composer.json
@@ -12,22 +12,36 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "symfony/symfony": "~2.8|~3.0",
-        "sensio/framework-extra-bundle": "^3.0.2|^5.0.0",
-        "doctrine/orm": "^2.4.8|^2.5",
-        "doctrine/doctrine-bundle": "^1.4|^1.6",
-        "mtdowling/cron-expression": "^1.2"
+        "php": ">=7.0.8",
+        "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/console": "^3.4|^4.0",
+        "sensio/framework-extra-bundle": "^5.1.0",
+        "doctrine/orm": "^2.5.11",
+        "doctrine/doctrine-bundle": "^1.6.10",
+        "mtdowling/cron-expression": "^1.2",
+        "symfony/security-bundle": "^3.4|^4.0",
+        "symfony/twig-bundle": "^3.4|^4.0",
+        "symfony/translation": "^3.4|^4.0",
+        "symfony/form": "^3.4|^4.0",
+        "symfony/asset": "^3.4|^4.0",
+        "symfony/templating": "^3.4|^4.0",
+        "symfony/validator": "^3.4|^4.0",
+        "symfony/css-selector": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
-        "satooshi/php-coveralls": "~1.0",
-        "doctrine/doctrine-fixtures-bundle": "~2.4",
-        "liip/functional-test-bundle": "^1.6"
+        "phpunit/phpunit": "^6.5",
+        "satooshi/php-coveralls": "^2.0",
+        "doctrine/doctrine-fixtures-bundle": "^3.0.0",
+        "liip/functional-test-bundle": "^1.9"
     },
     "autoload": {
         "psr-4": {
             "JMose\\CommandSchedulerBundle\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "Tests/"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
     -->
 
     <php>
+        <server name="KERNEL_CLASS" value="App\Tests\App\AppKernel" />
         <server name="KERNEL_DIR" value="./Tests/App" />
         <ini name="zend.enable_gc" value="0" />
         <!-- disable E_USER_DEPRECATED -->


### PR DESCRIPTION
I dropped Symfony <3.4, added support for Symfony 4.0, and bumped the minimum PHP version to 7.0.8.

Because that is a _lot_ of BC breaks, I updated the README to say it was v2.0.0 and the new minimum requirements.

There is more documentation to do, but I wanted to create this pull request and open discussion on what I've done.

This would close #81.