### PR TITLE
support symfony 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/asset": "^3.4|^4.0",
         "symfony/templating": "^3.4|^4.0",
         "symfony/validator": "^3.4|^4.0",
-        "symfony/css-selector": "^4.0"
+        "symfony/css-selector": "^3.4|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",


### PR DESCRIPTION
```
  Problem 1
    - Conclusion: remove symfony/symfony v3.4.4
    - Conclusion: don't install symfony/symfony v3.4.4
    - Conclusion: don't install symfony/symfony v3.4.3
    - Installation request for jmose/command-scheduler-bundle dev-master -> satisfiable by jmose/command-scheduler-bundle[dev-master].
    - Conclusion: don't install symfony/symfony v3.4.2
    - Conclusion: don't install symfony/symfony v3.4.1
    - jmose/command-scheduler-bundle dev-master requires symfony/css-selector ^4.0 -> satisfiable by symfony/css-selector[v4.0.0, v4.0.1, v4.0.2, v4.0.3, v4.0.4].
    - don't install symfony/css-selector v4.0.0|don't install symfony/symfony v3.4.0
    - don't install symfony/css-selector v4.0.1|don't install symfony/symfony v3.4.0
    - don't install symfony/css-selector v4.0.2|don't install symfony/symfony v3.4.0
    - don't install symfony/css-selector v4.0.3|don't install symfony/symfony v3.4.0
    - don't install symfony/css-selector v4.0.4|don't install symfony/symfony v3.4.0
    - Installation request for symfony/symfony 3.4.* -> satisfiable by symfony/symfony[v3.4.0, v3.4.1, v3.4.2, v3.4.3, v3.4.4].
```