### PR TITLE
fixed message when invalid use of unlock command

### DIFF
--- a/Command/UnlockCommand.php
+++ b/Command/UnlockCommand.php
@@ -88,7 +88,7 @@ class UnlockCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($this->unlockAll === false && $this->scheduledCommandName === '') {
+        if ($this->unlockAll === false && $this->scheduledCommandName === NULL) {
             $output->writeln('Either the name of a scheduled command or the --all option must be set.');
 
             return 1;


### PR DESCRIPTION
This fix allows the message resulting of invalid use of scheduler:unlock command to be shown when neither schedule command nor --all option are set.