### PR TITLE
Add EasyAdmin Configuration

### DIFF
--- a/Resources/config/easyadmin.yml
+++ b/Resources/config/easyadmin.yml
@@ -1,0 +1,37 @@
+# This config can be used to manage CommandScheduler via the EasyAdminBundle
+# To include this file put the following in the imports of your config.yml
+# - { resource: "@JMose/CommandSchedulerBundle/Resource/config/easyadmin.yml" }
+easy_admin:
+  entities:
+    Cron:
+      label: 'Command Scheduler'
+      class: JMose\CommandSchedulerBundle\Entity\ScheduledCommand
+      list:
+        title: "Command CRON Scheduler"
+        fields:
+          - id
+          - name
+          - command
+          - arguments
+          - lastExecution
+          - { property: 'lastReturncode', label: 'Last Returncode' }
+          - { property: 'locked', label: 'Locked', type: 'boolean' }
+          - priority
+          - disabled
+        form_filters:
+          - disabled
+          - locked
+      form:
+        fields:
+          - { type: 'section', label: 'Command Details' }
+          - name
+          - { property: 'command', type: 'JMose\CommandSchedulerBundle\Form\Type\CommandChoiceType' }
+          - arguments
+          - cronExpression
+          - priority
+          - disabled
+          - { type: 'section', label: 'Miscellaneous Settings' }
+          - logFile
+      new:
+        fields:
+         - executeImmediately

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -203,5 +203,16 @@ The call returns a JSON object with either HTTP 200 and an empty array (everythi
 For "internal" monitoring of jobs there is also a command "scheduler:monitor" which does the same check as the monitor call before except it sends emails to an arbitrary number of receivers (if the server allows sending mails with the "mail" command).
 As some kind of "self-monitoring" job the monitor command can be configured to send emails to all receivers if everything's ok - if there is no mail at all a problem occured.
 
+Integrate in EasyAdmin
+===============
+
+If you want to manage your scheduled commands via [EasyAdmin](https://github.com/EasyCorp/EasyAdminBundle) you can easily include it by importing our EasyAdmin config in your config.yml.
+
+```yaml
+# app/config/config.yml
+imports:
+ # ....
+  - { resource: "@JMose/CommandSchedulerBundle/Resource/config/easyadmin.yml" }
+```
 
 For any comments, questions, or bug report, use the  [Github issue tracker](https://github.com/J-Mose/CommandSchedulerBundle/issues).


### PR DESCRIPTION
Hi all,

I really wanted this bundle to be used in my project but I didn't want to have yet another admin panel, so I integrated it into the config of EasyAdminBundle which I was already using. I think a lot of people would enjoy to use this too so I propose this as a new feature that can be added to the bundle itself.

To do:
- [x] Create configuration
- [x] Add the option to the documentation.
- [ ] Translations (?)

If you think this idea is bonkers or shouldn't be default in the bundle, feel free to decline the PR.

All feedback is welcome!

Greetings,

Robin

Screenshots:

- List:
![List](https://i.imgur.com/5OydNoz.png)

- Create:
![Create](https://i.imgur.com/hw6WYUX.png)

- Edit:
![Edit](https://i.imgur.com/96k0BIL.png)