### PR TITLE
Correct use of TranslatorInterface in DI

### DIFF
--- a/Controller/BaseController.php
+++ b/Controller/BaseController.php
@@ -3,7 +3,7 @@
 namespace JMose\CommandSchedulerBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class BaseController
@@ -19,7 +19,7 @@ abstract class BaseController extends AbstractController
     private $managerName;
 
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -32,9 +32,9 @@ abstract class BaseController extends AbstractController
     }
 
     /**
-     * @param Translator $translator
+     * @param TranslatorInterface $translator
      */
-    public function setTranslator(Translator $translator)
+    public function setTranslator(TranslatorInterface $translator)
     {
         $this->translator = $translator;
     }


### PR DESCRIPTION
See https://github.com/J-Mose/CommandSchedulerBundle/issues/116#issuecomment-447598720

Correct use of `TranslatorInterface` in dependency injection.
Cannot use `symfony/contract`'s interface for now for BC reason.