### PR TITLE
force status refresh before command execution

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -119,6 +119,11 @@ class ExecuteCommand extends Command
         $noneExecution = true;
         foreach ($commands as $command) {
 
+            $this->em->refresh($this->em->merge($command));
+            if ($command->isDisabled() || $command->isLocked()) {
+                continue;
+            }
+
             /** @var ScheduledCommand $command */
             $cron = CronExpression::factory($command->getCronExpression());
             $nextRunDate = $cron->getNextRunDate($command->getLastExecution());


### PR DESCRIPTION
to force status refresh before command execution is necessary to prevent double execution when more than one schedule:execute process is running at the same time.

when a schedule:execute process is spawned by cron, it FIRST loads the status of every command and THEN tries to execute those commands by checking the schedule time details.

that might create a double command execution bug when another schedule:execute process is spawned by cron before the first one finishes, this might happen quite often when one or more scheduled commands require much time to be fulfilled (our case). 

since the first process has still the old status in memory, it can't understand that the second process has already executed the remaining commands, and so it executes those commands again, introducing a command execution duplication bug.

forcing the scheduler to refresh a command status before its execution solves the problem.

solves #127 