### PR TITLE
Update documentation to fix #125

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -114,7 +114,8 @@ jmose_command_scheduler:
     # receivers for reporting mails
     monitor_mail: []
     # set a custom subject for monitor mails (first placeholder will be replaced by the hostname, second by the date)
-    monitor_mail_subject: cronjob monitoring %s, %s
+    # double percentage is used to escape the percentage so they stay parameters
+    monitor_mail_subject: cronjob monitoring %%s, %%s
     # to send "everything's all right" emails to receivers for reporting mails set this value to "true" (see monitoring)
     send_ok: false
 


### PR DESCRIPTION
Issue #125 is possibly caused by the config proposed in this documentation section, which leads to Symfony thinking `%s, %` is a parameter resp. needs a parameter with id `s, `.