### PR TITLE
Clear ORM after run scheduled command

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -238,6 +238,8 @@ class ExecuteCommand extends Command
                 .' '.$scheduledCommand->getArguments().'</comment>'
             );
             $result = $command->run($input, $logOutput);
+
+            $this->em->clear();
         } catch (\Exception $e) {
             $logOutput->writeln($e->getMessage());
             $logOutput->writeln($e->getTraceAsString());
@@ -248,6 +250,8 @@ class ExecuteCommand extends Command
             $output->writeln('<comment>Entity manager closed by the last command.</comment>');
             $this->em = $this->em->create($this->em->getConnection(), $this->em->getConfiguration());
         }
+
+        $scheduledCommand = $this->em->find(ScheduledCommand::class, $scheduledCommand);
 
         $scheduledCommand->setLastReturnCode($result);
         $scheduledCommand->setLocked(false);


### PR DESCRIPTION
This PR clears ORM after run scheduled command. This security adds a separation between CommandSchedulerBundle and the Application.

If the scheduled command manipulates an application entity without doing any flush, CommandSchedulerBundle should NOT perform any flush on application entities.

Because the CommandSchedulerBundle entity will be detached by the clear action, the second line will reload this entity from database.