### PR TITLE
Restrict visibility of methods overriding `TestCase::setUp()`

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,8 +8,9 @@ return PhpCsFixer\Config::create()
     ->setRules(
         [
             '@Symfony' => true,
-            'no_superfluous_phpdoc_tags' => false,
             'array_syntax' => ['syntax' => 'short'],
+            'no_superfluous_phpdoc_tags' => false,
+            'php_unit_set_up_tear_down_visibility' => true,
         ]
     )
     ->setFinder($finder);

--- a/Tests/Command/MonitorCommandTest.php
+++ b/Tests/Command/MonitorCommandTest.php
@@ -21,7 +21,7 @@ class MonitorCommandTest extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         self::bootKernel();
 

--- a/Tests/Command/UnlockCommandTest.php
+++ b/Tests/Command/UnlockCommandTest.php
@@ -22,7 +22,7 @@ class UnlockCommandTest extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         self::bootKernel();
 

--- a/Tests/Controller/ListControllerTest.php
+++ b/Tests/Controller/ListControllerTest.php
@@ -27,7 +27,7 @@ class ListControllerTest extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->client = self::createClient();
         $this->em = static::$kernel->getContainer()


### PR DESCRIPTION
Also, the PHP-CS-Fixer rule `php_unit_set_up_tear_down_visibility` was configured to avoid regressions in the future.