### PR TITLE
Bump minimum PHP version to 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,14 @@ language: php
 
 matrix:
     include:
-        - php: 7.2
-          env: DEPENDENCIES="symfony/lts:3"
         - php: 7.3
           env: DEPENDENCIES="symfony/lts:3"
         - php: 7.4
-          env: DEPENDENCIES="symfony/lts:3"
-        - php: 7.2
           env: DEPENDENCIES="symfony/lts:4.x-dev"
         - php: 7.3
           env: DEPENDENCIES="symfony/lts:4.x-dev"
         - php: 7.4
           env: DEPENDENCIES="symfony/lts:4.x-dev"
-        - php: 7.2
         - php: 7.3
         - php: 7.4
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "symfony/console": "^3.4|^4.3|^5.0",
         "doctrine/orm": "^2.5.11",
         "doctrine/doctrine-bundle": "^1.6.10|^2.0",
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "ext-pcntl": "*",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5|^9.5",
         "php-coveralls/php-coveralls": "^2.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0.0",
         "liip/functional-test-bundle": "^4.2",


### PR DESCRIPTION
Tests are already using features that are available only in version equal or higher than 7.3, like the `void` return type.