### PR TITLE
Use entity class name to get repository

### DIFF
--- a/Controller/ListController.php
+++ b/Controller/ListController.php
@@ -32,9 +32,7 @@ class ListController extends BaseController
      */
     public function indexAction()
     {
-        $scheduledCommands = $this->getDoctrineManager()->getRepository(
-            'JMoseCommandSchedulerBundle:ScheduledCommand'
-        )->findAll();
+        $scheduledCommands = $this->getDoctrineManager()->getRepository(ScheduledCommand::class)->findAll();
 
         return $this->render(
             '@JMoseCommandScheduler/List/index.html.twig',


### PR DESCRIPTION
In the other methods of this controller this is done in the same way and in our usage of the bundle the current code produces an error where the doctrine mapper cannot find the entity class.
`Class 'JMoseCommandSchedulerBundle:ScheduledCommand' does not exist`